### PR TITLE
Scrum 110 sponsors promotion

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -1,0 +1,1 @@
+threshold: medium

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,3 @@
-from utils.api import Router
 from .router import router
 from .schemas.sponsors_component import SponsorsComponent
 from services.component_registry import ComponentRegistry

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,16 @@
+from utils.api import Router
+from .router import router
+from .schemas.sponsors_component import SponsorsComponent
+from services.component_registry import ComponentRegistry
+
+def register_plugin():
+    ComponentRegistry.register_component(SponsorsComponent)
+    print("Sponsors component registered.")
+    return router
+
+def unregister_plugin():
+    ComponentRegistry.unregister_component("SponsorsComponent")
+    print("Sponsors component unregistered.")
+
+REGISTER = register_plugin
+UNREGISTER = unregister_plugin

--- a/__init__.py
+++ b/__init__.py
@@ -1,15 +1,18 @@
 from .router import router
 from .schemas.sponsors_component import SponsorsComponent
 from services.component_registry import ComponentRegistry
+import logging
+
+logger = logging.getLogger("coffeebreak.core")
 
 def register_plugin():
     ComponentRegistry.register_component(SponsorsComponent)
-    print("Sponsors component registered.")
+    logger.debug("Sponsors component registered.")
     return router
 
 def unregister_plugin():
     ComponentRegistry.unregister_component("SponsorsComponent")
-    print("Sponsors component unregistered.")
+    logger.debug("Sponsors component unregistered.")
 
 REGISTER = register_plugin
 UNREGISTER = unregister_plugin

--- a/models/sponsors.py
+++ b/models/sponsors.py
@@ -1,0 +1,19 @@
+from dependencies.database import Base
+from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy.orm import relationship
+
+class Sponsor(Base):
+    __tablename__ = "sponsors"
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, index=True)
+    logo_url = Column(String)
+    website_url = Column(String)
+    description = Column(String)
+    level_id = Column(Integer, ForeignKey("levels.id"))
+    level = relationship("Level", back_populates="sponsors")
+
+class Level(Base):
+    __tablename__ = "levels"
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, index=True)
+    sponsors = relationship("Sponsor", back_populates="level")

--- a/router/__init__.py
+++ b/router/__init__.py
@@ -1,7 +1,7 @@
-from utils.api import Router
+from fastapi import APIRouter
 from .sponsors import router as sponsors_router
 
-router = Router()
+router = APIRouter()
 
 router.include_router(sponsors_router, prefix="/sponsors", tags=["Sponsors"])
 

--- a/router/__init__.py
+++ b/router/__init__.py
@@ -1,0 +1,8 @@
+from utils.api import Router
+from .sponsors import router as sponsors_router
+
+router = Router()
+
+router.include_router(sponsors_router, prefix="/sponsors", tags=["Sponsors"])
+
+__all__ = ["router"]

--- a/router/__init__.py
+++ b/router/__init__.py
@@ -1,8 +1,7 @@
-from fastapi import APIRouter
+from utils.api import Router
 from .sponsors import router as sponsors_router
 
-router = APIRouter()
-
-router.include_router(sponsors_router, prefix="/sponsors", tags=["Sponsors"])
+router = Router()
+router.include_router(sponsors_router, prefix="/sponsors")
 
 __all__ = ["router"]

--- a/router/sponsors.py
+++ b/router/sponsors.py
@@ -10,6 +10,10 @@ from ..schemas.sponsors import (
 from ..schemas.sponsors_component import SponsorsComponent
 from typing import List
 
+# Error message constants
+SPONSOR_NOT_FOUND = "Sponsor not found"
+LEVEL_NOT_FOUND = "Level not found"
+
 router = APIRouter()
 
 @router.get("/", response_model=SponsorsComponent)
@@ -39,7 +43,7 @@ def update_sponsor(sponsor_id: int, sponsor: SponsorUpdate, db: Session = Depend
     """
     db_sponsor = db.query(Sponsor).filter(Sponsor.id == sponsor_id).first()
     if not db_sponsor:
-        raise HTTPException(status_code=404, detail="Sponsor not found")
+        raise HTTPException(status_code=404, detail=SPONSOR_NOT_FOUND)
     
     for key, value in sponsor.model_dump(exclude_unset=True).items():
         setattr(db_sponsor, key, value)
@@ -55,7 +59,7 @@ def delete_sponsor(sponsor_id: int, db: Session = Depends(get_db)):
     """
     db_sponsor = db.query(Sponsor).filter(Sponsor.id == sponsor_id).first()
     if not db_sponsor:
-        raise HTTPException(status_code=404, detail="Sponsor not found")
+        raise HTTPException(status_code=404, detail=SPONSOR_NOT_FOUND)
     
     db.delete(db_sponsor)
     db.commit()
@@ -66,7 +70,7 @@ def create_level(level: LevelCreate, db: Session = Depends(get_db)):
     """
     Create a new sponsor level.
     """
-    db_level = Level(**level.dict())
+    db_level = Level(**level.model_dump())
     db.add(db_level)
     db.commit()
     db.refresh(db_level)
@@ -79,9 +83,9 @@ def update_level(level_id: int, level: LevelUpdate, db: Session = Depends(get_db
     """
     db_level = db.query(Level).filter(Level.id == level_id).first()
     if not db_level:
-        raise HTTPException(status_code=404, detail="Level not found")
+        raise HTTPException(status_code=404, detail=LEVEL_NOT_FOUND)
     
-    for key, value in level.dict(exclude_unset=True).items():
+    for key, value in level.model_dump(exclude_unset=True).items():
         setattr(db_level, key, value)
     
     db.commit()
@@ -95,7 +99,7 @@ def delete_level(level_id: int, db: Session = Depends(get_db)):
     """
     db_level = db.query(Level).filter(Level.id == level_id).first()
     if not db_level:
-        raise HTTPException(status_code=404, detail="Level not found")
+        raise HTTPException(status_code=404, detail=LEVEL_NOT_FOUND)
     
     db.delete(db_level)
     db.commit()
@@ -116,6 +120,6 @@ def get_level(level_id: int, db: Session = Depends(get_db)):
     """
     db_level = db.query(Level).filter(Level.id == level_id).first()
     if not db_level:
-        raise HTTPException(status_code=404, detail="Level not found")
+        raise HTTPException(status_code=404, detail=LEVEL_NOT_FOUND)
     
     return db_level

--- a/router/sponsors.py
+++ b/router/sponsors.py
@@ -26,7 +26,11 @@ def get_sponsors(db: Session = Depends(get_db)):
     return SponsorsComponent(sponsors=sponsors, levels=levels)
 
 @router.post("/", response_model=SponsorResponse)
-def create_sponsor(sponsor: SponsorCreate, db: Session = Depends(get_db)):
+def create_sponsor(
+    sponsor: SponsorCreate,
+    db: Session = Depends(get_db),
+    user_info: dict = Depends(check_role(["manage_sponsors"]))
+):
     """
     Create a new sponsor.
     """
@@ -37,7 +41,12 @@ def create_sponsor(sponsor: SponsorCreate, db: Session = Depends(get_db)):
     return db_sponsor
 
 @router.put("/{sponsor_id}", response_model=SponsorResponse)
-def update_sponsor(sponsor_id: int, sponsor: SponsorUpdate, db: Session = Depends(get_db)):
+def update_sponsor(
+    sponsor_id: int,
+    sponsor: SponsorUpdate,
+    db: Session = Depends(get_db),
+    user_info: dict = Depends(check_role(["manage_sponsors"]))
+):
     """
     Update an existing sponsor.
     """
@@ -53,7 +62,11 @@ def update_sponsor(sponsor_id: int, sponsor: SponsorUpdate, db: Session = Depend
     return db_sponsor
 
 @router.delete("/{sponsor_id}", response_model=SponsorResponse)
-def delete_sponsor(sponsor_id: int, db: Session = Depends(get_db)):
+def delete_sponsor(
+    sponsor_id: int,
+    db: Session = Depends(get_db),
+    user_info: dict = Depends(check_role(["manage_sponsors"]))
+):
     """
     Delete a sponsor.
     """
@@ -66,7 +79,11 @@ def delete_sponsor(sponsor_id: int, db: Session = Depends(get_db)):
     return db_sponsor
 
 @router.post("/levels/", response_model=LevelResponse)
-def create_level(level: LevelCreate, db: Session = Depends(get_db)):
+def create_level(
+    level: LevelCreate,
+    db: Session = Depends(get_db),
+    user_info: dict = Depends(check_role(["manage_sponsors"]))
+):
     """
     Create a new sponsor level.
     """
@@ -77,7 +94,12 @@ def create_level(level: LevelCreate, db: Session = Depends(get_db)):
     return db_level
 
 @router.put("/levels/{level_id}", response_model=LevelResponse)
-def update_level(level_id: int, level: LevelUpdate, db: Session = Depends(get_db)):
+def update_level(
+    level_id: int,
+    level: LevelUpdate,
+    db: Session = Depends(get_db),
+    user_info: dict = Depends(check_role(["manage_sponsors"]))
+):
     """
     Update an existing sponsor level.
     """
@@ -93,7 +115,11 @@ def update_level(level_id: int, level: LevelUpdate, db: Session = Depends(get_db
     return db_level
 
 @router.delete("/levels/{level_id}", response_model=LevelResponse)
-def delete_level(level_id: int, db: Session = Depends(get_db)):
+def delete_level(
+    level_id: int,
+    db: Session = Depends(get_db),
+    user_info: dict = Depends(check_role(["manage_sponsors"]))
+):
     """
     Delete a sponsor level.
     """

--- a/router/sponsors.py
+++ b/router/sponsors.py
@@ -1,4 +1,4 @@
-from fastapi import Depends, HTTPException, APIRouter
+from utils.api import Router, Depends
 from sqlalchemy.orm import Session
 from dependencies.database import get_db
 from dependencies.auth import check_role
@@ -14,16 +14,25 @@ from typing import List
 SPONSOR_NOT_FOUND = "Sponsor not found"
 LEVEL_NOT_FOUND = "Level not found"
 
-router = APIRouter()
+router = Router()
 
-@router.get("/", response_model=SponsorsComponent)
-def get_sponsors(db: Session = Depends(get_db)):
+@router.get("/component/", response_model=SponsorsComponent)
+def get_sponsors_component(db: Session = Depends(get_db)):
     """
-    Get all sponsors and their levels.
+    Get all sponsors with their levels.
     """
     sponsors = db.query(Sponsor).all()
     levels = db.query(Level).all()
-    return SponsorsComponent(sponsors=sponsors, levels=levels)
+    sponsors_component = SponsorsComponent(sponsors=sponsors, levels=levels)
+    return sponsors_component
+
+@router.get("/", response_model=List[SponsorResponse])
+def get_sponsors(db: Session = Depends(get_db)):
+    """
+    Get all sponsors.
+    """
+    sponsors = db.query(Sponsor).all()
+    return sponsors
 
 @router.post("/", response_model=SponsorResponse)
 def create_sponsor(

--- a/router/sponsors.py
+++ b/router/sponsors.py
@@ -1,0 +1,118 @@
+from fastapi import Depends, HTTPException
+from sqlalchemy.orm import Session
+from utils.api import Router
+from dependencies.database import get_db
+from dependencies.auth import check_role
+from ..models.sponsors import Sponsor, Level
+from ..schemas.sponsors import SponsorCreate, SponsorUpdate, LevelCreate, LevelUpdate
+from ..schemas.sponsors_component import SponsorsComponent
+
+router = Router()
+
+@router.get("/", response_model=SponsorsComponent)
+def get_sponsors(db: Session = Depends(get_db)):
+    """
+    Get all sponsors and their levels.
+    """
+    sponsors = db.query(Sponsor).all()
+    levels = db.query(Level).all()
+    return SponsorsComponent(sponsors=sponsors, levels=levels)
+
+@router.post("/", response_model=Sponsor)
+def create_sponsor(sponsor: SponsorCreate, db: Session = Depends(get_db)):
+    """
+    Create a new sponsor.
+    """
+    db_sponsor = Sponsor(**sponsor.dict())
+    db.add(db_sponsor)
+    db.commit()
+    db.refresh(db_sponsor)
+    return db_sponsor
+
+@router.put("/{sponsor_id}", response_model=Sponsor)
+def update_sponsor(sponsor_id: int, sponsor: SponsorUpdate, db: Session = Depends(get_db)):
+    """
+    Update an existing sponsor.
+    """
+    db_sponsor = db.query(Sponsor).filter(Sponsor.id == sponsor_id).first()
+    if not db_sponsor:
+        raise HTTPException(status_code=404, detail="Sponsor not found")
+    
+    for key, value in sponsor.dict(exclude_unset=True).items():
+        setattr(db_sponsor, key, value)
+    
+    db.commit()
+    db.refresh(db_sponsor)
+    return db_sponsor
+
+@router.delete("/{sponsor_id}", response_model=Sponsor)
+def delete_sponsor(sponsor_id: int, db: Session = Depends(get_db)):
+    """
+    Delete a sponsor.
+    """
+    db_sponsor = db.query(Sponsor).filter(Sponsor.id == sponsor_id).first()
+    if not db_sponsor:
+        raise HTTPException(status_code=404, detail="Sponsor not found")
+    
+    db.delete(db_sponsor)
+    db.commit()
+    return db_sponsor
+
+@router.post("/levels/", response_model=Level)
+def create_level(level: LevelCreate, db: Session = Depends(get_db)):
+    """
+    Create a new sponsor level.
+    """
+    db_level = Level(**level.dict())
+    db.add(db_level)
+    db.commit()
+    db.refresh(db_level)
+    return db_level
+
+@router.put("/levels/{level_id}", response_model=Level)
+def update_level(level_id: int, level: LevelUpdate, db: Session = Depends(get_db)):
+    """
+    Update an existing sponsor level.
+    """
+    db_level = db.query(Level).filter(Level.id == level_id).first()
+    if not db_level:
+        raise HTTPException(status_code=404, detail="Level not found")
+    
+    for key, value in level.dict(exclude_unset=True).items():
+        setattr(db_level, key, value)
+    
+    db.commit()
+    db.refresh(db_level)
+    return db_level
+
+@router.delete("/levels/{level_id}", response_model=Level)
+def delete_level(level_id: int, db: Session = Depends(get_db)):
+    """
+    Delete a sponsor level.
+    """
+    db_level = db.query(Level).filter(Level.id == level_id).first()
+    if not db_level:
+        raise HTTPException(status_code=404, detail="Level not found")
+    
+    db.delete(db_level)
+    db.commit()
+    return db_level
+
+@router.get("/levels/", response_model=List[Level]) 
+def get_levels(db: Session = Depends(get_db)):
+    """
+    Get all sponsor levels.
+    """
+    levels = db.query(Level).all()
+    return levels
+
+@router.get("/levels/{level_id}", response_model=Level)
+def get_level(level_id: int, db: Session = Depends(get_db)):
+    """
+    Get a specific sponsor level by ID.
+    """
+    db_level = db.query(Level).filter(Level.id == level_id).first()
+    if not db_level:
+        raise HTTPException(status_code=404, detail="Level not found")
+    
+    return db_level

--- a/schemas/sponsors.py
+++ b/schemas/sponsors.py
@@ -40,3 +40,14 @@ class SponsorUpdate(BaseModel):
     class Config:
         from_attributes = True
 
+class LevelCreate(BaseModel):
+    name: str = Field(..., title="Level Name", max_length=255)
+
+    class Config:
+        from_attributes = True
+
+class LevelUpdate(BaseModel):
+    name: Optional[str] = Field(None, title="Level Name", max_length=255)
+
+    class Config:
+        from_attributes = True

--- a/schemas/sponsors.py
+++ b/schemas/sponsors.py
@@ -40,6 +40,17 @@ class SponsorUpdate(BaseModel):
     class Config:
         from_attributes = True
 
+class SponsorResponse(BaseModel):
+    id: int
+    name: str
+    logo_url: str
+    website_url: str
+    level_id: int
+    description: Optional[str] = None
+    
+    class Config:
+        from_attributes = True
+
 class LevelCreate(BaseModel):
     name: str = Field(..., title="Level Name", max_length=255)
 
@@ -49,5 +60,14 @@ class LevelCreate(BaseModel):
 class LevelUpdate(BaseModel):
     name: Optional[str] = Field(None, title="Level Name", max_length=255)
 
+    class Config:
+        from_attributes = True
+
+class LevelResponse(BaseModel):
+    id: int
+    name: str
+    price: float
+    benefits: str
+    
     class Config:
         from_attributes = True

--- a/schemas/sponsors.py
+++ b/schemas/sponsors.py
@@ -1,0 +1,42 @@
+from pydantic import BaseModel, Field
+from typing import Optional, List
+
+class Sponsor(BaseModel):
+    id: Optional[int] = Field(None, title="Sponsor ID")
+    name: str = Field(..., title="Sponsor Name", max_length=255)
+    logo_url: Optional[str] = Field(None, title="Logo URL", max_length=255)
+    website_url: Optional[str] = Field(None, title="Website URL", max_length=255)
+    description: Optional[str] = Field(None, title="Description", max_length=1000)
+    level_id: Optional[int] = Field(None, title="Level ID")
+
+    class Config:
+        from_attributes = True
+
+class Level(BaseModel):
+    id: Optional[int] = Field(None, title="Level ID")
+    name: str = Field(..., title="Level Name", max_length=255)
+    sponsors: List[Sponsor] = []
+
+    class Config:
+        from_attributes = True
+
+class SponsorCreate(BaseModel):
+    name: str = Field(..., title="Sponsor Name", max_length=255)
+    logo_url: Optional[str] = Field(None, title="Logo URL", max_length=255)
+    website_url: Optional[str] = Field(None, title="Website URL", max_length=255)
+    description: Optional[str] = Field(None, title="Description", max_length=1000)
+    level_id: int = Field(..., title="Level ID")
+
+    class Config:
+        from_attributes = True
+
+class SponsorUpdate(BaseModel):
+    name: Optional[str] = Field(None, title="Sponsor Name", max_length=255)
+    logo_url: Optional[str] = Field(None, title="Logo URL", max_length=255)
+    website_url: Optional[str] = Field(None, title="Website URL", max_length=255)
+    description: Optional[str] = Field(None, title="Description", max_length=1000)
+    level_id: Optional[int] = Field(None, title="Level ID")
+
+    class Config:
+        from_attributes = True
+

--- a/schemas/sponsors.py
+++ b/schemas/sponsors.py
@@ -1,41 +1,50 @@
 from pydantic import BaseModel, Field
 from typing import Optional, List
 
+# Constants for field titles to avoid duplication
+WEBSITE_URL_TITLE = "Website URL"
+SPONSOR_NAME_TITLE = "Sponsor Name"
+LOGO_URL_TITLE = "Logo URL"
+DESCRIPTION_TITLE = "Description"
+LEVEL_ID_TITLE = "Level ID"
+LEVEL_NAME_TITLE = "Level Name"
+SPONSOR_ID_TITLE = "Sponsor ID"
+
 class Sponsor(BaseModel):
-    id: Optional[int] = Field(None, title="Sponsor ID")
-    name: str = Field(..., title="Sponsor Name", max_length=255)
-    logo_url: Optional[str] = Field(None, title="Logo URL", max_length=255)
-    website_url: Optional[str] = Field(None, title="Website URL", max_length=255)
-    description: Optional[str] = Field(None, title="Description", max_length=1000)
-    level_id: Optional[int] = Field(None, title="Level ID")
+    id: Optional[int] = Field(None, title=SPONSOR_ID_TITLE)
+    name: str = Field(..., title=SPONSOR_NAME_TITLE, max_length=255)
+    logo_url: Optional[str] = Field(None, title=LOGO_URL_TITLE, max_length=255)
+    website_url: Optional[str] = Field(None, title=WEBSITE_URL_TITLE, max_length=255)
+    description: Optional[str] = Field(None, title=DESCRIPTION_TITLE, max_length=1000)
+    level_id: Optional[int] = Field(None, title=LEVEL_ID_TITLE)
 
     class Config:
         from_attributes = True
 
 class Level(BaseModel):
-    id: Optional[int] = Field(None, title="Level ID")
-    name: str = Field(..., title="Level Name", max_length=255)
+    id: Optional[int] = Field(None, title=LEVEL_ID_TITLE)
+    name: str = Field(..., title=LEVEL_NAME_TITLE, max_length=255)
     sponsors: List[Sponsor] = []
 
     class Config:
         from_attributes = True
 
 class SponsorCreate(BaseModel):
-    name: str = Field(..., title="Sponsor Name", max_length=255)
-    logo_url: Optional[str] = Field(None, title="Logo URL", max_length=255)
-    website_url: Optional[str] = Field(None, title="Website URL", max_length=255)
-    description: Optional[str] = Field(None, title="Description", max_length=1000)
-    level_id: int = Field(..., title="Level ID")
+    name: str = Field(..., title=SPONSOR_NAME_TITLE, max_length=255)
+    logo_url: Optional[str] = Field(None, title=LOGO_URL_TITLE, max_length=255)
+    website_url: Optional[str] = Field(None, title=WEBSITE_URL_TITLE, max_length=255)
+    description: Optional[str] = Field(None, title=DESCRIPTION_TITLE, max_length=1000)
+    level_id: int = Field(..., title=LEVEL_ID_TITLE)
 
     class Config:
         from_attributes = True
 
 class SponsorUpdate(BaseModel):
-    name: Optional[str] = Field(None, title="Sponsor Name", max_length=255)
-    logo_url: Optional[str] = Field(None, title="Logo URL", max_length=255)
-    website_url: Optional[str] = Field(None, title="Website URL", max_length=255)
-    description: Optional[str] = Field(None, title="Description", max_length=1000)
-    level_id: Optional[int] = Field(None, title="Level ID")
+    name: Optional[str] = Field(None, title=SPONSOR_NAME_TITLE, max_length=255)
+    logo_url: Optional[str] = Field(None, title=LOGO_URL_TITLE, max_length=255)
+    website_url: Optional[str] = Field(None, title=WEBSITE_URL_TITLE, max_length=255)
+    description: Optional[str] = Field(None, title=DESCRIPTION_TITLE, max_length=1000)
+    level_id: Optional[int] = Field(None, title=LEVEL_ID_TITLE)
 
     class Config:
         from_attributes = True
@@ -52,13 +61,13 @@ class SponsorResponse(BaseModel):
         from_attributes = True
 
 class LevelCreate(BaseModel):
-    name: str = Field(..., title="Level Name", max_length=255)
+    name: str = Field(..., title=LEVEL_NAME_TITLE, max_length=255)
 
     class Config:
         from_attributes = True
 
 class LevelUpdate(BaseModel):
-    name: Optional[str] = Field(None, title="Level Name", max_length=255)
+    name: Optional[str] = Field(None, title=LEVEL_NAME_TITLE, max_length=255)
 
     class Config:
         from_attributes = True

--- a/schemas/sponsors_component.py
+++ b/schemas/sponsors_component.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel, Field
+from schemas.ui.page import BaseComponentSchema
+
+class SponsorsComponent(BaseComponentSchema):
+    """
+    Schema for the Sponsors component.
+    """
+    sponsors: list = Field([], title="Sponsors List", description="List of sponsors with their details.")
+    levels: list = Field([], title="Levels List", description="List of sponsor levels.")
+    display_sponsor_level: bool = Field(False, title="Display Sponsor Level", description="Flag to display sponsor level.")
+    display_sponsor_website: bool = Field(False, title="Display Sponsor Website", description="Flag to display sponsor website.")
+    display_sponsor_description: bool = Field(False, title="Display Sponsor Description", description="Flag to display sponsor description.")
+
+    class Config:
+        from_attributes = True

--- a/schemas/sponsors_component.py
+++ b/schemas/sponsors_component.py
@@ -1,12 +1,14 @@
-from pydantic import BaseModel, Field
+from pydantic import Field
 from schemas.ui.page import BaseComponentSchema
+from .sponsors import SponsorResponse, LevelResponse
 
 class SponsorsComponent(BaseComponentSchema):
     """
     Schema for the Sponsors component.
     """
-    sponsors: list = Field([], title="Sponsors List", description="List of sponsors with their details.")
-    levels: list = Field([], title="Levels List", description="List of sponsor levels.")
+    name: str = Field("SponsorsComponent", title="Component Name", description="Name of the component.")
+    sponsors: list = Field([SponsorResponse], title="Sponsors List", description="List of sponsors with their details.")
+    levels: list = Field([LevelResponse], title="Levels List", description="List of sponsor levels.")
     display_sponsor_level: bool = Field(False, title="Display Sponsor Level", description="Flag to display sponsor level.")
     display_sponsor_website: bool = Field(False, title="Display Sponsor Website", description="Flag to display sponsor website.")
     display_sponsor_description: bool = Field(False, title="Display Sponsor Description", description="Flag to display sponsor description.")


### PR DESCRIPTION
This pull request introduces a new feature for managing sponsors and their levels in the application. The changes include the addition of new models, schemas, and routes to handle CRUD operations for sponsors and their levels, as well as the registration of a new plugin component.

### New Models and Schemas:

* [`models/sponsors.py`](diffhunk://#diff-6fac094478eecd030faa8e2c8e0520c8d78b13f098cd135fe5108bf06e0b6f29R1-R19): Added `Sponsor` and `Level` models to represent sponsors and their levels in the database.
* [`schemas/sponsors.py`](diffhunk://#diff-85e3b8ac37ea9af4c33ef476dd960816af13a02e5de7d072743db9ef200c4f9aR1-R82): Created Pydantic schemas for sponsor and level data, including `SponsorCreate`, `SponsorUpdate`, `SponsorResponse`, `LevelCreate`, `LevelUpdate`, and `LevelResponse`.
* [`schemas/sponsors_component.py`](diffhunk://#diff-5e5adceb7e328160e24183772bd7ecb0f212ccd7adcfb508d5120ed415d5537fR1-R17): Added `SponsorsComponent` schema to represent the sponsors component.

### New Routes:

* [`router/sponsors.py`](diffhunk://#diff-662f913b30627066a3d68c11b1de920fae5541ea7be5ffe26d691d8a239493abR1-R160): Implemented routes for CRUD operations on sponsors and levels, including endpoints to create, read, update, and delete sponsors and levels.
* [`router/__init__.py`](diffhunk://#diff-b4dbaace8ef74fe84717a8932062e85c956f485809802b155d18f39eee3f03ceR1-R7): Included the sponsors router with the prefix `/sponsors`.

### Plugin Registration:

* [`__init__.py`](diffhunk://#diff-8e2c1f727276d30ced72fa67cb848772a9802162bec39b42a8df5359fd063a4cR1-R15): Added functions to register and unregister the sponsors component plugin with the `ComponentRegistry`.

### Configuration:

* [`.talismanrc`](diffhunk://#diff-efcd051724f24a743f7e1d572b337b61f6a1137ea138173c59346095eedd972aR1): Updated the threshold to medium.