### PR TITLE
fix levelResponse

### DIFF
--- a/schemas/sponsors.py
+++ b/schemas/sponsors.py
@@ -75,8 +75,6 @@ class LevelUpdate(BaseModel):
 class LevelResponse(BaseModel):
     id: int
     name: str
-    price: float
-    benefits: str
     
     class Config:
         from_attributes = True


### PR DESCRIPTION
This pull request includes a minor change to the `schemas/sponsors.py` file. It removes two fields, `price` and `benefits`, from the `LevelResponse` model.

* [`schemas/sponsors.py`](diffhunk://#diff-85e3b8ac37ea9af4c33ef476dd960816af13a02e5de7d072743db9ef200c4f9aL78-L79): Removed the `price` and `benefits` fields from the `LevelResponse` model, simplifying its structure.