### PR TITLE
feat: add pyproject.toml manifest and simplify plugin init

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,24 +1,11 @@
 from .router import router
 from .schemas.sponsors_component import SponsorsComponent
 from coffeebreak import ComponentRegistry
-import logging
 
-logger = logging.getLogger("coffeebreak.core")
 
-PLUGIN_TITLE = "sponsors-promotion-plugin"
-NAME = "Sponsors Promotion Plugin"
-DESCRIPTION = "A plugin to promote sponsors"
-
-def register_plugin():
+def REGISTER():
     ComponentRegistry.register_component(SponsorsComponent)
-    logger.debug("Sponsors component registered.")
-    return router
 
-def unregister_plugin():
+
+def UNREGISTER():
     ComponentRegistry.unregister_component("SponsorsComponent")
-    logger.debug("Sponsors component unregistered.")
-
-REGISTER = register_plugin
-UNREGISTER = unregister_plugin
-
-CONFIG_PAGE = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.coffeebreak]
+identifier = "sponsors-promotion-plugin"
+name = "Sponsors Promotion Plugin"
+description = "A plugin to promote sponsors"
+config_page = true


### PR DESCRIPTION
## Summary
- Added `pyproject.toml` with `[tool.coffeebreak]` manifest for plugin metadata
- Simplified `__init__.py` — removed metadata constants, logger, and REGISTER/UNREGISTER indirection
- Metadata is now handled by the core automatically via the manifest